### PR TITLE
fix(https): Apply protocol option to webm URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ function getWebmList (board, threadNo, callback, options) {
   const protocol = options.https ? 'https' : 'http'
   const apiUrl = `${protocol}://a.4cdn.org/${board}/thread/${threadNo}.json`
   
-  const getWebmUrl = tim => `http://i.4cdn.org/${board}/${tim}.webm`
+  const getWebmUrl = tim => `${protocol}://i.4cdn.org/${board}/${tim}.webm`
   const isWebm = x => x.ext === '.webm'
   const reducer = (acc, cur) => acc.concat([{filename: cur.filename, url: getWebmUrl(cur.tim)}])
 


### PR DESCRIPTION
## Context

The `https` option isn't being applied when generating webm URLs, which will produce a message, `connection not fully secure`, when users access website and SSL certificate information.

## Objective 

* Prepend `${protocol}` to the webm URL, instead of hard-coding `http`