### PR TITLE
test(struct): Test structure of webm object payload

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,7 @@ describe('/GET webm data from a thread', function () {
     const { subject, webms } = data
 
     expect(webms).to.be.an('array').that.is.not.empty
+    expect(webms[0]).to.have.all.keys(['filename', 'url', 'thumbnail'])
     expect(subject).to.equal(sub)
   })
 
@@ -38,6 +39,7 @@ describe('/GET webm data from a thread', function () {
     const { subject, webms } = data
 
     expect(webms).to.be.an('array').that.is.not.empty
+    expect(webms[0]).to.have.all.keys(['filename', 'url', 'thumbnail'])
     expect(subject).to.equal(sub)
   })
 


### PR DESCRIPTION
## Context

There are currently no tests testing the structure of `webm` objects.

## Objective

* Test to ensure `webm` objects have the following structure:

```json
{
  "filename": "...",
  "url": "...",
  "thumbnail": "..."
}